### PR TITLE
Fix directory capitalization

### DIFF
--- a/pgui.exw
+++ b/pgui.exw
@@ -97,7 +97,7 @@ if platform()=LINUX then fatal("linux") end if
 if machine_bits()=64 then fatal("64-bit") end if
 
 --with trace
-include demo\arwen\arwen.ew
+include demo\arwen\Arwen.ew
 --include demo\arwen\axtra.e
 --with trace
 


### PR DESCRIPTION
On Linux, directory capitalization matters. This makes Arwen build.